### PR TITLE
Set cas tries to 0 before raising a Client Error

### DIFF
--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -431,8 +431,8 @@ Please note that when <tt>:no_block => true</tt>, update methods do not raise on
   # CAS stands for "compare and swap", and avoids the need for manual key mutexing. CAS support must be enabled in Memcached.new or a <b>Memcached::ClientError</b> will be raised. Note that CAS may be buggy in memcached itself.
   # :retry_on_exceptions does not apply to this method
   def cas(keys, ttl=@default_ttl, decode=true)
-    raise ClientError, "CAS not enabled for this Memcached instance" unless options[:support_cas]
     tries ||= 0
+    raise ClientError, "CAS not enabled for this Memcached instance" unless options[:support_cas]
 
     if keys.is_a? Array
       # Multi CAS


### PR DESCRIPTION
I noticed a bug where if the options don't support compare and swap, we raise a client error, but we still look to retry before seeing if the error should be retried.

The options I could think of were:

1) Reverse the check, to see if we should retry first, but someone could override the options (I think) to allow ClientError to be retried
2) use `.to_i` on `tries` to force nil to be 0.
3) Just initialize tries on the first line of the method.

I went with 3, but I'm happy to switch to something else.

```
bundler/gems/memcached-74b654d4b45f/lib/memcached/memcached.rb:457:in `rescue in cas': undefined method `<' for nil:NilClass (NoMethodError)
from bundler/gems/memcached-74b654d4b45f/lib/memcached/memcached.rb:436:in `cas'     from gems/memcached_store-2.3.1/lib/active_support/cache/memcached_store.rb:134:in `block (2 levels) in cas'     from bundler/gems/rails-4850a02741c5/activesupport/lib/active_support/cache.rb:775:in `block in instrument'     from bundler/gems/rails-4850a02741c5/activesupport/lib/active_support/notifications.rb:206:in `block in instrument'     from bundler/gems/rails-4850a02741c5/activesupport/lib/active_support/notifications/instrumenter.rb:24:in `instrument'     from bundler/gems/rails-4850a02741c5/activesupport/lib/active_support/notifications.rb:206:in `instrument'     from bundler/gems/rails-4850a02741c5/activesupport/lib/active_support/cache.rb:775:in `instrument'     from gems/memcached_store-2.3.1/lib/active_support/cache/memcached_store.rb:133:in `block in cas'     from gems/memcached_store-2.3.1/lib/active_support/cache/memcached_store.rb:342:in `handle_exceptions'     from lib/active_support/cache/snappy_pack_memcached_store.rb:57:in `handle_exceptions'     from gems/memcached_store-2.3.1/lib/active_support/cache/memcached_store.rb:132:in `cas'     from lib/active_support/cache/strategy/high_throughput_local_cache.rb:157:in `cas'     from lib/active_support/cache/proxy_cache_store.rb:99:in `cas'     from bundler/gems/identity_cache-771b0f983242/lib/identity_cache/cache_fetcher.rb:179:in `upsert'     from bundler/gems/identity_cache-771b0f983242/lib/identity_cache/cache_fetcher.rb:86:in `fetch_without_fill_lock'     from bundler/gems/identity_cache-771b0f983242/lib/identity_cache/cache_fetcher.rb:78:in `fetch'     from lib/active_support/cache/strategy/high_throughput_local_cache.rb:123:in `fetch'
```