### PR TITLE
Avoid overflowing stack with too many keys

### DIFF
--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -621,9 +621,9 @@ Please note that when <tt>:no_block => true</tt>, update methods do not raise on
 
   # Turn an array of keys into a hash of keys to servers.
   def inspect_keys(keys, server = nil)
-    Hash[*Array(keys).map do |key|
+    Hash[Array(keys).map do |key|
       [key, server || server_by_key(key)]
-    end.flatten]
+    end]
   end
 
   # Find which server failed most recently.


### PR DESCRIPTION
If a client attempts to to a get_multi with a very large number of keys, inspect_keys will fail with `stack level too deep (SystemStackError)`

The underlying cause of the overflow is due to the way `inspect_keys` creates a hash, and can be illustrated with:

```
Hash[*(['a', 'a'] * 2000000000)]
```

Because of SystemStackError's parent, unless you explicitly rescue with `rescue Exception` it will sail through an empty rescue block:

```
irb(main):038:1* begin
irb(main):039:1*   raise SystemStackError.new("hi")
irb(main):040:1* rescue
irb(main):041:1*   puts "fine"
irb(main):042:0> end
(irb):39:in `<main>': hi (SystemStackError)
```

This overflow can be fixed using an alternative form for `Hash[]` which passes the values as a single array argument.

It'll probably still break horribly, but hopefully in a more conventional way. 😅 