### PR TITLE
Make the library fork safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,22 +3,30 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-
     strategy:
+      fail-fast: false
       matrix:
         ruby:
-          - '2.5' # earliest supported
-          - '3.0' # latest release
-
+          - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
     steps:
-    - run: |
-        sudo apt-get update
-        sudo apt-get -y install memcached libsasl2-dev
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - run: bundle exec ruby test/setup.rb
-    - run: bundle exec rake
-    - run: bundle exec rake install
+      - run: |
+          sudo apt-get update
+          sudo apt-get -y install memcached libsasl2-dev
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec ruby test/setup.rb
+      - run: bundle exec rake
+
+      # Unclear why this fails on 3.0+
+      # ERROR:  Error installing /home/runner/work/memcached/memcached/pkg/memcached-1.9.0.gem:
+      # ERROR: Failed to build gem native extension.
+      #
+      #   No such file or directory @ dir_s_mkdir - /home/runner/work/memcached/memcached/vendor/bundle/ruby/3.2.0/gems/memcached-1.9.0/ext/rlibmemcached/.gem.20230731-7980-75spno
+      #
+      # - run: bundle exec rake build install

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,4 +47,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.1.4
+   2.4.17

--- a/ext/rlibmemcached/rlibmemcached_wrap.c
+++ b/ext/rlibmemcached/rlibmemcached_wrap.c
@@ -7520,6 +7520,27 @@ fail:
 
 
 SWIGINTERN VALUE
+_wrap_memcached_discard(int argc, VALUE *argv, VALUE self) {
+  memcached_st *arg1 = (memcached_st *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(argv[0], &argp1,SWIGTYPE_p_memcached_st, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "memcached_st *","memcached_discard", 1, argv[0] )); 
+  }
+  arg1 = (memcached_st *)(argp1);
+  memcached_discard(arg1);
+  return Qnil;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
 _wrap_memcached_strerror(int argc, VALUE *argv, VALUE self) {
   memcached_st *arg1 = (memcached_st *) 0 ;
   memcached_return arg2 ;
@@ -13651,6 +13672,7 @@ SWIGEXPORT void Init_rlibmemcached(void) {
   rb_define_module_function(mRlibmemcached, "memcached_flush", _wrap_memcached_flush, -1);
   rb_define_module_function(mRlibmemcached, "memcached_verbosity", _wrap_memcached_verbosity, -1);
   rb_define_module_function(mRlibmemcached, "memcached_quit", _wrap_memcached_quit, -1);
+  rb_define_module_function(mRlibmemcached, "memcached_discard", _wrap_memcached_discard, -1);
   rb_define_module_function(mRlibmemcached, "memcached_strerror", _wrap_memcached_strerror, -1);
   rb_define_module_function(mRlibmemcached, "memcached_behavior_set", _wrap_memcached_behavior_set, -1);
   rb_define_module_function(mRlibmemcached, "memcached_behavior_get", _wrap_memcached_behavior_get, -1);

--- a/lib/memcached/behaviors.rb
+++ b/lib/memcached/behaviors.rb
@@ -52,14 +52,14 @@ class Memcached
 
     lib_value = BEHAVIOR_VALUES[value] || (value * (CONVERSION_FACTORS[behavior] || 1)).to_i
     #STDERR.puts "Setting #{behavior}:#{b_id} => #{value} (#{lib_value})"
-    Lib.memcached_behavior_set(@struct, b_id, lib_value)
+    Lib.memcached_behavior_set(memcached_struct, b_id, lib_value)
     #STDERR.puts " -> set to #{get_behavior(behavior).inspect}"
   end
 
   # Get a behavior value for this Memcached instance. Accepts a Symbol.
   def get_behavior(behavior)
     raise ArgumentError, "No behavior #{behavior.inspect}" unless b_id = BEHAVIORS[behavior]
-    value = Lib.memcached_behavior_get(@struct, b_id)
+    value = Lib.memcached_behavior_get(memcached_struct, b_id)
 
     if BEHAVIOR_VALUES.invert.has_key?(value)
       # False, nil are valid values so we can not rely on direct lookups

--- a/lib/memcached/experimental.rb
+++ b/lib/memcached/experimental.rb
@@ -3,7 +3,7 @@ class Memcached
     # TOUCH is used to set a new expiration time for an existing item
     def touch(key, ttl=@default_ttl)
       check_return_code(
-        Lib.memcached_touch(@struct, key, ttl),
+        Lib.memcached_touch(memcached_struct, key, ttl),
         key
       )
     rescue => e

--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -107,7 +107,8 @@ Please note that when <tt>:no_block => true</tt>, update methods do not raise on
 =end
 
   def initialize(servers = nil, opts = {})
-    @struct = Lib.memcached_create(nil)
+    @pid = Process.pid
+    @_memcached_struct = Lib.memcached_create(nil)
 
     # Merge option defaults and discard meaningless keys
     @options = DEFAULTS.merge(opts)
@@ -185,12 +186,12 @@ Please note that when <tt>:no_block => true</tt>, update methods do not raise on
       # Socket
       check_return_code(
         if server.is_a?(String) and File.socket?(server)
-          args = [@struct, server, options[:default_weight].to_i]
+          args = [memcached_struct, server, options[:default_weight].to_i]
           Lib.memcached_server_add_unix_socket_with_weight(*args)
         # Network
         elsif server.is_a?(String) and server =~ /^[\w\.-]+(:\d{1,5}){0,2}$/
           host, port, weight = server.split(":")
-          args = [@struct, host, port.to_i, (weight || options[:default_weight]).to_i]
+          args = [memcached_struct, host, port.to_i, (weight || options[:default_weight]).to_i]
           if options[:use_udp]
             Lib.memcached_server_add_udp_with_weight(*args)
           else
@@ -221,17 +222,17 @@ But it was #{server}.
         key += options[:prefix_delimiter]
         raise ArgumentError, "Max prefix key + prefix delimiter size is #{Lib::MEMCACHED_PREFIX_KEY_MAX_SIZE - 1}" unless
           key.size < Lib::MEMCACHED_PREFIX_KEY_MAX_SIZE
-        Lib.memcached_callback_set(@struct, Lib::MEMCACHED_CALLBACK_PREFIX_KEY, key)
+        Lib.memcached_callback_set(memcached_struct, Lib::MEMCACHED_CALLBACK_PREFIX_KEY, key)
       else
-        Lib.memcached_callback_set(@struct, Lib::MEMCACHED_CALLBACK_PREFIX_KEY, "")
+        Lib.memcached_callback_set(memcached_struct, Lib::MEMCACHED_CALLBACK_PREFIX_KEY, "")
       end
     )
   end
 
   # Return the current prefix key.
   def prefix_key
-    if @struct.prefix_key.size > 0
-      @struct.prefix_key[0..-1 - options[:prefix_delimiter].size]
+    if memcached_struct.prefix_key.size > 0
+      memcached_struct.prefix_key[0..-1 - options[:prefix_delimiter].size]
     else
       ""
     end
@@ -244,8 +245,8 @@ But it was #{server}.
   #
   def clone
     memcached = super
-    struct = Lib.memcached_clone(nil, @struct)
-    memcached.instance_variable_set('@struct', struct)
+    struct = Lib.memcached_clone(nil, memcached_struct)
+    memcached.instance_variable_set(:@_memcached_struct, struct)
     memcached
   end
 
@@ -258,7 +259,7 @@ But it was #{server}.
 
     # Create
     # FIXME Duplicates logic with initialize()
-    @struct = Lib.memcached_create(nil)
+    @_memcached_struct = Lib.memcached_create(nil)
     set_prefix_key(prev_prefix_key)
     set_behaviors
     set_credentials
@@ -267,7 +268,7 @@ But it was #{server}.
 
   # Disconnect from all currently connected servers
   def quit
-    Lib.memcached_quit(@struct)
+    Lib.memcached_quit(memcached_struct)
     self
   end
 
@@ -285,12 +286,23 @@ But it was #{server}.
 
   private
 
+  def memcached_struct
+    if @pid != Process.pid
+      old_struct = @_memcached_struct
+      @_memcached_struct = Lib.memcached_clone(nil, old_struct)
+      raise "memcached_clone returned nil" unless @_memcached_struct
+      Lib.memcached_discard(old_struct) # discard the connection without sending QUIT or FIN
+      @pid = Process.pid
+    end
+    @_memcached_struct or raise "No @_memcached_struct????"
+  end
+
   # Return an array of raw <tt>memcached_host_st</tt> structs for this instance.
   def server_structs
     array = []
-    if @struct.hosts
-      @struct.hosts.count.times do |i|
-        array << Lib.memcached_select_server_at(@struct, i)
+    if memcached_struct.hosts
+      memcached_struct.hosts.count.times do |i|
+        array << Lib.memcached_select_server_at(memcached_struct, i)
       end
     end
     array
@@ -312,7 +324,7 @@ But it was #{server}.
     value, flags = @codec.encode(key, value, flags) if encode
     begin
       check_return_code(
-        Lib.memcached_set(@struct, key, value, ttl, flags),
+        Lib.memcached_set(memcached_struct, key, value, ttl, flags),
         key
       )
     rescue => e
@@ -328,7 +340,7 @@ But it was #{server}.
     value, flags = @codec.encode(key, value, flags) if encode
     begin
       check_return_code(
-        Lib.memcached_add(@struct, key, value, ttl, flags),
+        Lib.memcached_add(memcached_struct, key, value, ttl, flags),
         key
       )
     rescue => e
@@ -345,7 +357,7 @@ But it was #{server}.
   #
   # Note that the key must be initialized to an unencoded integer first, via <tt>set</tt>, <tt>add</tt>, or <tt>replace</tt> with <tt>encode</tt> set to <tt>false</tt>.
   def increment(key, offset=1)
-    ret, value = Lib.memcached_increment(@struct, key, offset)
+    ret, value = Lib.memcached_increment(memcached_struct, key, offset)
     check_return_code(ret, key)
     value
   rescue => e
@@ -357,7 +369,7 @@ But it was #{server}.
 
   # Decrement a key's value. The parameters and exception behavior are the same as <tt>increment</tt>.
   def decrement(key, offset=1)
-    ret, value = Lib.memcached_decrement(@struct, key, offset)
+    ret, value = Lib.memcached_decrement(memcached_struct, key, offset)
     check_return_code(ret, key)
     value
   rescue => e
@@ -377,7 +389,7 @@ But it was #{server}.
     value, flags = @codec.encode(key, value, flags) if encode
     begin
       check_return_code(
-        Lib.memcached_replace(@struct, key, value, ttl, flags),
+        Lib.memcached_replace(memcached_struct, key, value, ttl, flags),
         key
       )
     rescue => e
@@ -394,7 +406,7 @@ But it was #{server}.
   def append(key, value)
     # Requires memcached 1.2.4
     check_return_code(
-      Lib.memcached_append(@struct, key, value.to_s, IGNORED, IGNORED),
+      Lib.memcached_append(memcached_struct, key, value.to_s, IGNORED, IGNORED),
       key
     )
   rescue => e
@@ -408,7 +420,7 @@ But it was #{server}.
   def prepend(key, value)
     # Requires memcached 1.2.4
     check_return_code(
-      Lib.memcached_prepend(@struct, key, value.to_s, IGNORED, IGNORED),
+      Lib.memcached_prepend(memcached_struct, key, value.to_s, IGNORED, IGNORED),
       key
     )
   rescue => e
@@ -457,7 +469,7 @@ But it was #{server}.
   # Deletes a key/value pair from the server. Accepts a String <tt>key</tt>. Raises <b>Memcached::NotFound</b> if the key does not exist.
   def delete(key)
     check_return_code(
-      Lib.memcached_delete(@struct, key, IGNORED),
+      Lib.memcached_delete(memcached_struct, key, IGNORED),
       key
     )
   rescue => e
@@ -470,7 +482,7 @@ But it was #{server}.
   # Flushes all key/value pairs from all the servers.
   def flush
     check_return_code(
-      Lib.memcached_flush(@struct, IGNORED)
+      Lib.memcached_flush(memcached_struct, IGNORED)
     )
   rescue => e
     tries ||= 0
@@ -508,7 +520,7 @@ But it was #{server}.
   # <tt>Memcached::NotFound</tt> if the key does not exist.
   def exist(key)
     check_return_code(
-      Lib.memcached_exist(@struct, key),
+      Lib.memcached_exist(memcached_struct, key),
       key
     )
   end
@@ -517,7 +529,7 @@ But it was #{server}.
   def get_from_last(key, decode=true)
     warn("Memcached#get_from_last is deprecated and was removed in newer versions of libmemcached")
     raise ArgumentError, "get_from_last() is not useful unless :random distribution is enabled." unless options[:distribution] == :random
-    value, flags, ret = Lib.memcached_get_from_last_rvalue(@struct, key)
+    value, flags, ret = Lib.memcached_get_from_last_rvalue(memcached_struct, key)
     check_return_code(ret, key)
     decode ? @codec.decode(key, value, flags) : value
   end
@@ -526,7 +538,7 @@ But it was #{server}.
 
   # Return the server used by a particular key.
   def server_by_key(key)
-    ret = Lib.memcached_server_by_key(@struct, key)
+    ret = Lib.memcached_server_by_key(memcached_struct, key)
     if ret.is_a?(Array)
       check_return_code(ret.last)
       inspect_server(ret.first)
@@ -540,18 +552,18 @@ But it was #{server}.
   def stats(subcommand = nil)
     stats = Hash.new([])
 
-    stat_struct, ret = Lib.memcached_stat(@struct, subcommand)
+    stat_struct, ret = Lib.memcached_stat(memcached_struct, subcommand)
     check_return_code(ret)
 
-    keys, ret = Lib.memcached_stat_get_keys(@struct, stat_struct)
+    keys, ret = Lib.memcached_stat_get_keys(memcached_struct, stat_struct)
     check_return_code(ret)
 
     keys.each do |key|
        server_structs.size.times do |index|
 
          value, ret = Lib.memcached_stat_get_value(
-           @struct,
-           Lib.memcached_select_stat_at(@struct, stat_struct, index),
+           memcached_struct,
+           Lib.memcached_select_stat_at(memcached_struct, stat_struct, index),
            key)
          check_return_code(ret, key)
 
@@ -565,7 +577,7 @@ But it was #{server}.
        end
     end
 
-    Lib.memcached_stat_free(@struct, stat_struct)
+    Lib.memcached_stat_free(memcached_struct, stat_struct)
     stats
   rescue Memcached::SomeErrorsWereReported => _
     e = _.class.new("Error getting stats")
@@ -597,16 +609,17 @@ But it was #{server}.
     message = "Key #{inspect_keys(key, (detect_failure if ret == Lib::MEMCACHED_SERVER_MARKED_DEAD)).inspect}" if key
     if key.is_a?(String)
       if ret == Lib::MEMCACHED_ERRNO
-        if (server = Lib.memcached_server_by_key(@struct, key)).is_a?(Array)
+        if (server = Lib.memcached_server_by_key(memcached_struct, key)).is_a?(Array)
           errno = server.first.cached_errno
           message = "Errno #{errno}: #{ERRNO_HASH[errno].inspect}. #{message}"
         end
       elsif ret == Lib::MEMCACHED_SERVER_ERROR
-        if (server = Lib.memcached_server_by_key(@struct, key)).is_a?(Array)
+        if (server = Lib.memcached_server_by_key(memcached_struct, key)).is_a?(Array)
           message = "\"#{server.first.cached_server_error}\". #{message}"
         end
       end
     end
+
     if EXCEPTIONS[ret]
       raise EXCEPTIONS[ret], message
     else
@@ -642,7 +655,7 @@ But it was #{server}.
 
   def destroy_credentials
     if options[:credentials] != nil
-      check_return_code(Lib.memcached_destroy_sasl_auth_data(@struct))
+      check_return_code(Lib.memcached_destroy_sasl_auth_data(memcached_struct))
     end
   end
 
@@ -650,7 +663,7 @@ But it was #{server}.
   def set_credentials
     if options[:credentials]
       check_return_code(
-        Lib.memcached_set_sasl_auth_data(@struct, *options[:credentials])
+        Lib.memcached_set_sasl_auth_data(memcached_struct, *options[:credentials])
       )
     end
   end
@@ -670,28 +683,28 @@ But it was #{server}.
   end
 
   def single_get(key, decode)
-    value, flags, ret = Lib.memcached_get_rvalue(@struct, key)
+    value, flags, ret = Lib.memcached_get_rvalue(memcached_struct, key)
     check_return_code(ret, key)
-    cas = @struct.result.cas if @support_cas
+    cas = memcached_struct.result.cas if @support_cas
     value = @codec.decode(key, value, flags) if decode
     [value, flags, cas]
   end
 
   def multi_get(keys, decode)
-    ret = Lib.memcached_mget(@struct, keys)
+    ret = Lib.memcached_mget(memcached_struct, keys)
     check_return_code(ret, keys)
 
     hash = {}
     flags_and_cas = {} if @support_cas
-    value, key, flags, ret = Lib.memcached_fetch_rvalue(@struct)
+    value, key, flags, ret = Lib.memcached_fetch_rvalue(memcached_struct)
     while ret != 21 do # Lib::MEMCACHED_END
       if ret == 0 # Lib::MEMCACHED_SUCCESS
-        flags_and_cas[key] = [flags, @struct.result.cas] if @support_cas
+        flags_and_cas[key] = [flags, memcached_struct.result.cas] if @support_cas
         hash[key] = decode ? [value, flags] : value
       elsif ret != 16 # Lib::MEMCACHED_NOTFOUND
         check_return_code(ret, key)
       end
-      value, key, flags, ret = Lib.memcached_fetch_rvalue(@struct)
+      value, key, flags, ret = Lib.memcached_fetch_rvalue(memcached_struct)
     end
     if decode
       hash.each do |inner_key, value_and_flags|
@@ -708,7 +721,7 @@ But it was #{server}.
       flags, cas = flags_and_cas[key]
       value, flags = @codec.encode(key, value, flags) if encode
       begin
-        ret = Lib.memcached_cas(@struct, key, value, ttl, flags, cas)
+        ret = Lib.memcached_cas(memcached_struct, key, value, ttl, flags, cas)
         if ret == 0 # Lib::MEMCACHED_SUCCESS
           result[key] = raw_value
         elsif ret != 12 && ret != 16 # Lib::MEMCACHED_DATA_EXISTS, Lib::MEMCACHED_NOTFOUND
@@ -726,7 +739,7 @@ But it was #{server}.
   def single_cas(key, value, ttl, flags, cas, encode)
     value, flags = @codec.encode(key, value, flags) if encode
     check_return_code(
-      Lib.memcached_cas(@struct, key, value, ttl, flags, cas),
+      Lib.memcached_cas(memcached_struct, key, value, ttl, flags, cas),
       key
     )
   end

--- a/test/unit/memcached_experimental_test.rb
+++ b/test/unit/memcached_experimental_test.rb
@@ -89,12 +89,12 @@ class MemcachedExperimentalTest < Test::Unit::TestCase
   # Memory cleanup
 
   def test_reset
-    original_struct = @cache.instance_variable_get("@struct")
+    original_struct = @cache.send(:memcached_struct)
     assert_nothing_raised do
       @cache.reset
     end
     assert_not_equal original_struct,
-      @cache.instance_variable_get("@struct")
+      @cache.send(:memcached_struct)
   end
 
   private

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -372,7 +372,7 @@ class MemcachedTest < Test::Unit::TestCase
     end).real
 
   ensure
-    socket.close
+    socket&.close
   end
 
   def test_get_with_prefix_key
@@ -403,7 +403,7 @@ class MemcachedTest < Test::Unit::TestCase
     @cache.set key, value
     result = @cache.get key, false
     non_wrapped_result = Rlibmemcached.memcached_get(
-      @cache.instance_variable_get("@struct"),
+      @cache.send(:memcached_struct),
       key
     ).first
     assert result.size > non_wrapped_result.size
@@ -1065,8 +1065,8 @@ class MemcachedTest < Test::Unit::TestCase
     assert_not_equal cache, @cache
 
     # Definitely check that the structs are unlinked
-    assert_not_equal @cache.instance_variable_get('@struct').object_id,
-      cache.instance_variable_get('@struct').object_id
+    assert_not_equal @cache.send(:memcached_struct).object_id,
+      cache.send(:memcached_struct).object_id
 
     assert_nothing_raised do
       @cache.set key, @value
@@ -1082,7 +1082,7 @@ class MemcachedTest < Test::Unit::TestCase
       cache.set key, @value
     end
     ret = Rlibmemcached.memcached_set(
-      cache.instance_variable_get("@struct"),
+      cache.send(:memcached_struct),
       key,
       @marshalled_value,
       0,
@@ -1096,7 +1096,7 @@ class MemcachedTest < Test::Unit::TestCase
       @noblock_cache.set key, @value
     end
     ret = Rlibmemcached.memcached_set(
-      @noblock_cache.instance_variable_get("@struct"),
+      @noblock_cache.send(:memcached_struct),
       key,
       @marshalled_value,
       0,
@@ -1328,7 +1328,7 @@ class MemcachedTest < Test::Unit::TestCase
 
     # This is an abuse of knowledge, but it's necessary to verify that
     # the library is handling the counter properly.
-    struct = cache.instance_variable_get(:@struct)
+    struct = cache.send(:memcached_struct)
     server = Rlibmemcached.memcached_server_by_key(struct, "marmotte").first
 
     # set to ensure connectivity
@@ -1474,12 +1474,12 @@ class MemcachedTest < Test::Unit::TestCase
   # Memory cleanup
 
   def test_reset
-    original_struct = @cache.instance_variable_get("@struct")
+    original_struct = @cache.send(:memcached_struct)
     assert_nothing_raised do
       @cache.reset
     end
     assert_not_equal original_struct,
-      @cache.instance_variable_get("@struct")
+      @cache.send(:memcached_struct)
   end
 
   # NOTE: This breaks encapsulation, but there's no other easy way to test this without
@@ -1496,6 +1496,91 @@ class MemcachedTest < Test::Unit::TestCase
 
   def test_interrupt_handling_no_block
     interrupt_test_with_options(key, @noblock_options)
+  end
+
+  if Process.respond_to?(:fork)
+    def _get_many(cache, key, count)
+      counts = Hash.new(0)
+
+      count.times do
+        counts[cache.get(key)] += 1
+      rescue Memcached::NotFound
+        counts[Memcached::NotFound] += 1
+      end
+
+      counts
+    end
+
+    def test_handle_fork
+      r, w = IO.pipe
+
+      pids = 5.times.map do |i|
+        key, value = "key-#{i}", "#{i}"
+        @cache.set(key, value)
+
+        Process.fork do
+          w.write(Marshal.dump({ key => _get_many(@cache, key, 10_000) }))
+          Process.exit!(0)
+        end
+      end
+
+      @cache.set("parent", "parent")
+      reads = { "parent" => _get_many(@cache, "parent", 100_000) }
+
+      5.times.each do
+        reads.merge!(Marshal.load(r))
+      end
+
+      pids.each do |pid|
+        _, status = Process.wait2(pid)
+        assert_predicate(status, :success?)
+      end
+
+      assert_equal(
+        {
+          "parent" => { "parent" => 100_000 },
+          "key-0" => { "0" => 10_000 },
+          "key-1" => { "1" => 10_000 },
+          "key-2" => { "2" => 10_000 },
+          "key-3" => { "3" => 10_000 },
+          "key-4" => { "4" => 10_000 },
+        },
+        reads,
+      )
+    end
+
+    def test_closing_in_child_doesnt_impact_parent
+      @cache.set("parent", "parent")
+
+      pid = Process.fork do
+        @cache.quit
+        Process.exit!(0)
+      end
+
+      _, status = Process.wait2(pid)
+      assert_predicate(status, :success?)
+
+      assert_equal "parent", @cache.get("parent")
+    end
+
+    def test_running_finalizer_in_child_doesnt_impact_parent
+      @cache.set("parent", "parent")
+
+      50.times do
+        assert_equal "parent", @cache.get("parent")
+        pid = Process.fork do
+          @cache = nil
+          # runs finalizers
+          GC.start
+          Process.exit(0)
+        end
+
+        assert_equal({ "parent" => 10000 }, _get_many(@cache, "parent", 10_000))
+
+        _, status = Process.wait2(pid)
+        assert_predicate(status, :success?)
+      end
+    end
   end
 
   private

--- a/vendor/libmemcached-0.32/libmemcached/memcached.c
+++ b/vendor/libmemcached-0.32/libmemcached/memcached.c
@@ -39,8 +39,12 @@ memcached_st *memcached_create(memcached_st *ptr)
 
 void memcached_free(memcached_st *ptr)
 {
-  /* If we have anything open, lets close it now */
-  memcached_quit(ptr);
+  // memcached_quit(ptr);
+  // PATCH: The original code calls `memcached_quit`, which sends a QUIT command
+  // before closing the socket.
+  // This is problematic in forking environment as it may break inherited connections.
+  // Ideally we'd call `memcached_quit` if the connection was established in that same process.
+  memcached_discard(ptr);
   server_list_free(ptr, ptr->hosts);
   memcached_result_free(&ptr->result);
 

--- a/vendor/libmemcached-0.32/libmemcached/memcached.c
+++ b/vendor/libmemcached-0.32/libmemcached/memcached.c
@@ -33,18 +33,14 @@ memcached_st *memcached_create(memcached_st *ptr)
   /* TODO, Document why we picked these defaults */
   ptr->io_msg_watermark= 500;
   ptr->io_bytes_watermark= 65 * 1024;
+  ptr->pid = getpid();
 
   return ptr;
 }
 
 void memcached_free(memcached_st *ptr)
 {
-  // memcached_quit(ptr);
-  // PATCH: The original code calls `memcached_quit`, which sends a QUIT command
-  // before closing the socket.
-  // This is problematic in forking environment as it may break inherited connections.
-  // Ideally we'd call `memcached_quit` if the connection was established in that same process.
-  memcached_discard(ptr);
+  memcached_quit(ptr);
   server_list_free(ptr, ptr->hosts);
   memcached_result_free(&ptr->result);
 
@@ -86,6 +82,7 @@ memcached_st *memcached_clone(memcached_st *clone, memcached_st *source)
   if (new_clone == NULL)
     return NULL;
 
+  new_clone->pid= getpid();
   new_clone->flags= source->flags;
   new_clone->send_size= source->send_size;
   new_clone->recv_size= source->recv_size;

--- a/vendor/libmemcached-0.32/libmemcached/memcached.h
+++ b/vendor/libmemcached-0.32/libmemcached/memcached.h
@@ -182,6 +182,8 @@ memcached_return memcached_verbosity(memcached_st *ptr, unsigned int verbosity);
 LIBMEMCACHED_API
 void memcached_quit(memcached_st *ptr);
 LIBMEMCACHED_API
+void memcached_discard(memcached_st *ptr);
+LIBMEMCACHED_API
 const char *memcached_strerror(memcached_st *ptr, memcached_return rc);
 LIBMEMCACHED_API
 memcached_return memcached_behavior_set(memcached_st *ptr, memcached_behavior flag, uint64_t data);

--- a/vendor/libmemcached-0.32/libmemcached/memcached.h
+++ b/vendor/libmemcached-0.32/libmemcached/memcached.h
@@ -122,6 +122,7 @@ struct memcached_st {
   const sasl_callback_t *sasl_callbacks;
 #endif
   int last_server_key;
+  pid_t pid;
 };
 
 LIBMEMCACHED_API

--- a/vendor/libmemcached-0.32/libmemcached/memcached_io.c
+++ b/vendor/libmemcached-0.32/libmemcached/memcached_io.c
@@ -310,6 +310,32 @@ memcached_return memcached_io_close(memcached_server_st *ptr)
   return MEMCACHED_SUCCESS;
 }
 
+memcached_return memcached_io_discard(memcached_server_st *ptr)
+{
+  int r;
+
+  if (ptr->fd == -1)
+    return MEMCACHED_SUCCESS;
+
+  int null_fd = open("/dev/null", O_RDWR | O_CLOEXEC);
+  if (null_fd < 0) {
+      return MEMCACHED_ERRNO;
+  }
+
+  if (dup2(null_fd, ptr->fd) < 0) {
+      close(null_fd);
+      return MEMCACHED_ERRNO;
+  }
+
+  if (close(null_fd) < 0) {
+      return MEMCACHED_ERRNO;
+  }
+
+  ptr->fd = -1;
+
+  return MEMCACHED_SUCCESS;
+}
+
 memcached_server_st *memcached_io_get_readable_server(memcached_st *memc)
 {
 #define MAX_SERVERS_TO_POLL 100

--- a/vendor/libmemcached-0.32/libmemcached/memcached_io.h
+++ b/vendor/libmemcached-0.32/libmemcached/memcached_io.h
@@ -55,6 +55,7 @@ memcached_return memcached_io_readline(memcached_server_st *ptr,
                                        char *buffer_ptr,
                                        size_t size);
 memcached_return memcached_io_close(memcached_server_st *ptr);
+memcached_return memcached_io_discard(memcached_server_st *ptr);
 /* Read n bytes of data from the server and store them in dta */
 memcached_return memcached_safe_read(memcached_server_st *ptr,
                                      void *dta,

--- a/vendor/libmemcached-0.32/libmemcached/memcached_quit.c
+++ b/vendor/libmemcached-0.32/libmemcached/memcached_quit.c
@@ -73,3 +73,42 @@ void memcached_quit(memcached_st *ptr)
       memcached_quit_server(&ptr->hosts[x], 0);
   }
 }
+
+// Past this point are custom extensions, not vanilla libmemcached
+void memcached_discard_server(memcached_server_st *ptr, uint8_t io_death)
+{
+  if (ptr->fd != -1)
+  {
+    memcached_io_discard(ptr);
+
+    ptr->fd= -1;
+    ptr->write_buffer_offset= (size_t) ((ptr->type == MEMCACHED_CONNECTION_UDP) ? UDP_DATAGRAM_HEADER_LENGTH : 0);
+    ptr->read_buffer_length= 0;
+    ptr->read_ptr= ptr->read_buffer;
+    memcached_server_response_reset(ptr);
+  }
+
+  if (io_death)
+  {
+    ptr->server_failure_counter++;
+  }
+  else
+  {
+    ptr->server_failure_counter = 0;
+  }
+}
+
+void memcached_discard(memcached_st *ptr)
+{
+  unsigned int x;
+
+  if (ptr->hosts == NULL || 
+      ptr->number_of_hosts == 0)
+    return;
+
+  if (ptr->hosts && ptr->number_of_hosts)
+  {
+    for (x= 0; x < ptr->number_of_hosts; x++)
+      memcached_discard_server(&ptr->hosts[x], 0);
+  }
+}

--- a/vendor/libmemcached-0.32/libmemcached/memcached_quit.c
+++ b/vendor/libmemcached-0.32/libmemcached/memcached_quit.c
@@ -1,5 +1,47 @@
 #include "common.h"
 
+
+// This is a custom extension, not vanilla libmemcached
+void memcached_discard_server(memcached_server_st *ptr, uint8_t io_death)
+{
+  if (ptr->fd != -1)
+  {
+    memcached_io_discard(ptr);
+
+    ptr->fd= -1;
+    ptr->write_buffer_offset= (size_t) ((ptr->type == MEMCACHED_CONNECTION_UDP) ? UDP_DATAGRAM_HEADER_LENGTH : 0);
+    ptr->read_buffer_length= 0;
+    ptr->read_ptr= ptr->read_buffer;
+    memcached_server_response_reset(ptr);
+  }
+
+  if (io_death)
+  {
+    ptr->server_failure_counter++;
+  }
+  else
+  {
+    ptr->server_failure_counter = 0;
+  }
+}
+
+void memcached_discard(memcached_st *ptr)
+{
+  unsigned int x;
+
+  if (ptr->hosts == NULL || 
+      ptr->number_of_hosts == 0)
+    return;
+
+  if (ptr->hosts && ptr->number_of_hosts)
+  {
+    for (x= 0; x < ptr->number_of_hosts; x++)
+      memcached_discard_server(&ptr->hosts[x], 0);
+  }
+}
+// end of custom extensions.
+
+
 /*
   This closes all connections (forces flush of input as well).
   
@@ -61,6 +103,13 @@ void memcached_quit_server(memcached_server_st *ptr, uint8_t io_death)
 
 void memcached_quit(memcached_st *ptr)
 {
+  if (ptr->pid != getpid()) {
+    // The connection was created in another process,
+    // let's not send a QUIT not call shutdown to avoid
+    // breaking the other process connection.
+    return memcached_discard(ptr);
+  }
+
   unsigned int x;
 
   if (ptr->hosts == NULL || 
@@ -71,44 +120,5 @@ void memcached_quit(memcached_st *ptr)
   {
     for (x= 0; x < ptr->number_of_hosts; x++)
       memcached_quit_server(&ptr->hosts[x], 0);
-  }
-}
-
-// Past this point are custom extensions, not vanilla libmemcached
-void memcached_discard_server(memcached_server_st *ptr, uint8_t io_death)
-{
-  if (ptr->fd != -1)
-  {
-    memcached_io_discard(ptr);
-
-    ptr->fd= -1;
-    ptr->write_buffer_offset= (size_t) ((ptr->type == MEMCACHED_CONNECTION_UDP) ? UDP_DATAGRAM_HEADER_LENGTH : 0);
-    ptr->read_buffer_length= 0;
-    ptr->read_ptr= ptr->read_buffer;
-    memcached_server_response_reset(ptr);
-  }
-
-  if (io_death)
-  {
-    ptr->server_failure_counter++;
-  }
-  else
-  {
-    ptr->server_failure_counter = 0;
-  }
-}
-
-void memcached_discard(memcached_st *ptr)
-{
-  unsigned int x;
-
-  if (ptr->hosts == NULL || 
-      ptr->number_of_hosts == 0)
-    return;
-
-  if (ptr->hosts && ptr->number_of_hosts)
-  {
-    for (x= 0; x < ptr->number_of_hosts; x++)
-      memcached_discard_server(&ptr->hosts[x], 0);
   }
 }


### PR DESCRIPTION
We record the pid when establishing the connection, and compare the recorded pid with the current one whenever we re-use the connection.

If we detect a change, we clone the connection and close the old one.

We make sure not to send `QUIT` when closing the old connection as it would break the parent's connection.

NB: `libmemcached` doesn't expose a way to close a connection without sending `QUIT`, so I had to patch it...