### PR TITLE
Support returning error values instead of raising in `get` and `cas`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,13 +17,15 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     memcache-client (1.8.5)
-    minitest (5.14.4)
-    mocha (1.12.0)
+    minitest (5.20.0)
+    mocha (2.1.0)
+      ruby2_keywords (>= 0.0.5)
     power_assert (2.0.0)
     rake (13.0.3)
     rake-compiler (1.1.1)
       rake
     remix-stash (1.1.3)
+    ruby2_keywords (0.0.5)
     stackprof (0.2.17)
     test-unit (3.4.0)
       power_assert
@@ -39,6 +41,7 @@ DEPENDENCIES
   dalli
   memcache-client
   memcached!
+  minitest
   mocha
   rake
   rake-compiler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    memcached (1.9.0)
+    memcached (1.10.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -61,6 +61,11 @@ class Memcached
 
   attr_reader :options # Return the options Hash used to configure this instance.
 
+  NOT_FOUND = BasicObject.new
+  def NOT_FOUND.inspect
+    "<Memcached::NOT_FOUND>"
+  end
+
 ###### Configuration
 
 =begin rdoc
@@ -177,6 +182,8 @@ Please note that when <tt>:no_block => true</tt>, update methods do not raise on
 
     # Not found exceptions
     @show_backtraces = options[:show_backtraces] ? nil : EMPTY_ARRAY
+
+    @raise_on_errors = true
   end
 
   # Set the server list.
@@ -453,6 +460,9 @@ But it was #{server}.
     else
       # Single CAS
       value, flags, cas = single_get(keys, decode)
+      if !@raise_on_errors && value.equal?(NOT_FOUND)
+        return NOT_FOUND
+      end
       value = yield value
       single_cas(keys, value, ttl, flags, cas, decode)
     end
@@ -585,6 +595,15 @@ But it was #{server}.
     raise e
   end
 
+  # Causes get / cas operations to return NOT_FOUND instead of raising NotFound
+  def without_exceptions(&block)
+    prev = @raise_on_errors
+    @raise_on_errors = false
+    yield
+  ensure
+    @raise_on_errors = prev
+  end
+
   ### Operations helpers
 
   private
@@ -684,6 +703,9 @@ But it was #{server}.
 
   def single_get(key, decode)
     value, flags, ret = Lib.memcached_get_rvalue(memcached_struct, key)
+    if ret == 16 && !@raise_on_errors
+      return [NOT_FOUND, nil, nil]
+    end
     check_return_code(ret, key)
     cas = memcached_struct.result.cas if @support_cas
     value = @codec.decode(key, value, flags) if decode
@@ -738,9 +760,10 @@ But it was #{server}.
 
   def single_cas(key, value, ttl, flags, cas, encode)
     value, flags = @codec.encode(key, value, flags) if encode
-    check_return_code(
-      Lib.memcached_cas(memcached_struct, key, value, ttl, flags, cas),
-      key
-    )
+    ret = Lib.memcached_cas(memcached_struct, key, value, ttl, flags, cas)
+    if ret == 16 && !@raise_on_errors
+      return NOT_FOUND
+    end
+    check_return_code(ret, key)
   end
 end

--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -603,6 +603,7 @@ But it was #{server}.
   private
 
   # Checks the return code from Rlibmemcached against the exception list. Raises the corresponding exception if the return code is not Memcached::Success or Memcached::ActionQueued. Accepts an integer return code and an optional key, for exception messages.
+  # When @raise_on_errors is false, `NOT_FOUND` is returned instead of raising an exception when the key is not found.
   def check_return_code(ret, key = nil) #:doc:
     case ret
     when 0  # Lib::MEMCACHED_SUCCESS

--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -66,6 +66,16 @@ class Memcached
     "<Memcached::NOT_FOUND>"
   end
 
+  NOT_STORED = BasicObject.new
+  def NOT_STORED.inspect
+    "<Memcached::NOT_STORED>"
+  end
+
+  DATA_EXISTS = BasicObject.new
+  def DATA_EXISTS.inspect
+    "<Memcached::DATA_EXISTS>"
+  end
+
 ###### Configuration
 
 =begin rdoc
@@ -603,22 +613,31 @@ But it was #{server}.
   private
 
   # Checks the return code from Rlibmemcached against the exception list. Raises the corresponding exception if the return code is not Memcached::Success or Memcached::ActionQueued. Accepts an integer return code and an optional key, for exception messages.
-  # When @raise_on_errors is false, `NOT_FOUND` is returned instead of raising an exception when the key is not found.
+  # When @raise_on_errors is false the following are returned instead of raiing exceptions:
+  # `NOT_STORED` is returned when ret == 12 (Lib::MEMCACHED_DATA_EXISTS)
+  # `NOT_FOUND` is returned when ret == 16 (Lib::MEMCACHED_NOTFOUND)
+  # `DATA_EXISTS` is returned when ret == 14 (Lib::MEMCACHED_NOTSTORED)
   def check_return_code(ret, key = nil) #:doc:
     case ret
     when 0  # Lib::MEMCACHED_SUCCESS
     when 32 # Lib::MEMCACHED_BUFFERED
-    when 16
+    when 16 # Lib::MEMCACHED_NOTFOUND
       if @raise_on_errors
-        raise NotFound, "NOTFOUND".freeze, @show_backtraces, cause: nil # Lib::MEMCACHED_NOTFOUND
+        raise NotFound, "NOTFOUND".freeze, @show_backtraces, cause: nil
       else
         NOT_FOUND
       end
-    when 14
+    when 14 # Lib::MEMCACHED_NOTSTORED
       if @raise_on_errors
-        raise NotStored, "NOTSTORED".freeze, @show_backtraces, cause: nil # Lib::MEMCACHED_NOTSTORED
+        raise NotStored, "NOTSTORED".freeze, @show_backtraces, cause: nil
       else
-        NOT_FOUND
+        NOT_STORED
+      end
+    when 12 # Lib::MEMCACHED_DATA_EXISTS
+      if @raise_on_errors
+        reraise(key, ret)
+      else
+        DATA_EXISTS
       end
     else
       reraise(key, ret)

--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -365,8 +365,7 @@ But it was #{server}.
   # Note that the key must be initialized to an unencoded integer first, via <tt>set</tt>, <tt>add</tt>, or <tt>replace</tt> with <tt>encode</tt> set to <tt>false</tt>.
   def increment(key, offset=1)
     ret, value = Lib.memcached_increment(memcached_struct, key, offset)
-    check_return_code(ret, key)
-    value
+    check_return_code(ret, key) || value
   rescue => e
     tries ||= 0
     raise unless tries < options[:exception_retry_limit] && should_retry(e)
@@ -377,8 +376,7 @@ But it was #{server}.
   # Decrement a key's value. The parameters and exception behavior are the same as <tt>increment</tt>.
   def decrement(key, offset=1)
     ret, value = Lib.memcached_decrement(memcached_struct, key, offset)
-    check_return_code(ret, key)
-    value
+    check_return_code(ret, key) || value
   rescue => e
     tries ||= 0
     raise unless tries < options[:exception_retry_limit] && should_retry(e)
@@ -460,9 +458,7 @@ But it was #{server}.
     else
       # Single CAS
       value, flags, cas = single_get(keys, decode)
-      if !@raise_on_errors && value.equal?(NOT_FOUND)
-        return NOT_FOUND
-      end
+      return NOT_FOUND if NOT_FOUND == value
       value = yield value
       single_cas(keys, value, ttl, flags, cas, decode)
     end
@@ -540,8 +536,7 @@ But it was #{server}.
     warn("Memcached#get_from_last is deprecated and was removed in newer versions of libmemcached")
     raise ArgumentError, "get_from_last() is not useful unless :random distribution is enabled." unless options[:distribution] == :random
     value, flags, ret = Lib.memcached_get_from_last_rvalue(memcached_struct, key)
-    check_return_code(ret, key)
-    decode ? @codec.decode(key, value, flags) : value
+    check_return_code(ret, key) || (decode ? @codec.decode(key, value, flags) : value)
   end
 
   ### Information methods
@@ -550,8 +545,7 @@ But it was #{server}.
   def server_by_key(key)
     ret = Lib.memcached_server_by_key(memcached_struct, key)
     if ret.is_a?(Array)
-      check_return_code(ret.last)
-      inspect_server(ret.first)
+      check_return_code(ret.last) || inspect_server(ret.first)
     else
       check_return_code(ret)
     end
@@ -610,12 +604,21 @@ But it was #{server}.
 
   # Checks the return code from Rlibmemcached against the exception list. Raises the corresponding exception if the return code is not Memcached::Success or Memcached::ActionQueued. Accepts an integer return code and an optional key, for exception messages.
   def check_return_code(ret, key = nil) #:doc:
-    if ret == 0 # Lib::MEMCACHED_SUCCESS
-    elsif ret == 32 # Lib::MEMCACHED_BUFFERED
-    elsif ret == 16
-      raise NotFound, "NOTFOUND".freeze, @show_backtraces, cause: nil # Lib::MEMCACHED_NOTFOUND
-    elsif ret == 14
-      raise NotStored, "NOTSTORED".freeze, @show_backtraces, cause: nil # Lib::MEMCACHED_NOTSTORED
+    case ret
+    when 0  # Lib::MEMCACHED_SUCCESS
+    when 32 # Lib::MEMCACHED_BUFFERED
+    when 16
+      if @raise_on_errors
+        raise NotFound, "NOTFOUND".freeze, @show_backtraces, cause: nil # Lib::MEMCACHED_NOTFOUND
+      else
+        NOT_FOUND
+      end
+    when 14
+      if @raise_on_errors
+        raise NotStored, "NOTSTORED".freeze, @show_backtraces, cause: nil # Lib::MEMCACHED_NOTSTORED
+      else
+        NOT_FOUND
+      end
     else
       reraise(key, ret)
     end
@@ -703,10 +706,10 @@ But it was #{server}.
 
   def single_get(key, decode)
     value, flags, ret = Lib.memcached_get_rvalue(memcached_struct, key)
-    if ret == 16 && !@raise_on_errors
-      return [NOT_FOUND, nil, nil]
-    end
-    check_return_code(ret, key)
+
+    result = check_return_code(ret, key)
+    return [NOT_FOUND, nil, nil] if result == NOT_FOUND
+
     cas = memcached_struct.result.cas if @support_cas
     value = @codec.decode(key, value, flags) if decode
     [value, flags, cas]
@@ -744,9 +747,12 @@ But it was #{server}.
       value, flags = @codec.encode(key, value, flags) if encode
       begin
         ret = Lib.memcached_cas(memcached_struct, key, value, ttl, flags, cas)
-        if ret == 0 # Lib::MEMCACHED_SUCCESS
+        case ret
+        when 0 # Lib::MEMCACHED_SUCCESS
           result[key] = raw_value
-        elsif ret != 12 && ret != 16 # Lib::MEMCACHED_DATA_EXISTS, Lib::MEMCACHED_NOTFOUND
+        when 12, 16 # Lib::MEMCACHED_DATA_EXISTS, Lib::MEMCACHED_NOTFOUND
+          # noop
+        else
           check_return_code(ret, key)
         end
       rescue => e
@@ -761,9 +767,6 @@ But it was #{server}.
   def single_cas(key, value, ttl, flags, cas, encode)
     value, flags = @codec.encode(key, value, flags) if encode
     ret = Lib.memcached_cas(memcached_struct, key, value, ttl, flags, cas)
-    if ret == 16 && !@raise_on_errors
-      return NOT_FOUND
-    end
     check_return_code(ret, key)
   end
 end

--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -613,7 +613,7 @@ But it was #{server}.
   private
 
   # Checks the return code from Rlibmemcached against the exception list. Raises the corresponding exception if the return code is not Memcached::Success or Memcached::ActionQueued. Accepts an integer return code and an optional key, for exception messages.
-  # When @raise_on_errors is false the following are returned instead of raiing exceptions:
+  # When @raise_on_errors is false the following are returned instead of raising exceptions:
   # `NOT_STORED` is returned when ret == 12 (Lib::MEMCACHED_DATA_EXISTS)
   # `NOT_FOUND` is returned when ret == 16 (Lib::MEMCACHED_NOTFOUND)
   # `DATA_EXISTS` is returned when ret == 14 (Lib::MEMCACHED_NOTSTORED)

--- a/memcached.gemspec
+++ b/memcached.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'activesupport'
+  s.add_development_dependency 'minitest'
   s.add_development_dependency "rake-compiler"
 end

--- a/memcached.gemspec
+++ b/memcached.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "memcached"
-  s.version = "1.9.0"
+  s.version = "1.10.0"
 
   s.authors = ["Arthur Neves", "Evan Weaver"]
   s.email = "arthurnn@gmail.com"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,9 +7,8 @@ require 'rubygems'
 require 'ruby-debug' if ENV['DEBUG']
 require 'memcached'
 
-require 'test/unit'
-require 'test/unit/assertions'
-require 'mocha/test_unit'
+require 'minitest/autorun'
+require 'mocha/minitest'
 require 'ostruct'
 require 'socket'
 
@@ -18,4 +17,16 @@ require_relative 'setup'
 UNIX_SOCKET_NAME = File.join(ENV['TMPDIR']||'/tmp','memcached') unless defined? UNIX_SOCKET_NAME
 
 class GenericClass
+end
+
+module Minitest::Assertions
+  private
+
+  def assert_nothing_raised(*)
+    yield
+  end
+
+  alias_method :assert_raise, :assert_raises
+  alias_method :assert_not_equal, :refute_equal
+  alias_method :assert_not_nil, :refute_nil
 end

--- a/test/unit/binding_test.rb
+++ b/test/unit/binding_test.rb
@@ -1,7 +1,7 @@
 
 require File.expand_path("#{File.dirname(__FILE__)}/../test_helper")
 
-class BindingTest < Test::Unit::TestCase
+class BindingTest < Minitest::Test
   def test_libmemcached_loaded
     Warning.expects(:warn).with(regexp_matches(/constant ::Rlibmemcached is deprecated/), optionally(anything))
     Rlibmemcached

--- a/test/unit/memcached_experimental_test.rb
+++ b/test/unit/memcached_experimental_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path("#{File.dirname(__FILE__)}/../test_helper")
 
-class MemcachedExperimentalTest < Test::Unit::TestCase
+class MemcachedExperimentalTest < Minitest::Test
 
   def setup
     @servers = ['localhost:43042', 'localhost:43043', "#{UNIX_SOCKET_NAME}0"]

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -1282,7 +1282,6 @@ class MemcachedTest < Minitest::Test
   end
 
   def test_unresponsive_server_retries_less_than_server_failure_limit
-    skip "This test is broken"
     socket = stub_server 43041
 
     cache = Memcached.new(
@@ -1298,6 +1297,10 @@ class MemcachedTest < Minitest::Test
 
     key2 = 'test_missing_server'
     assert_raise(Memcached::ATimeoutOccurred) { cache.set(key2, @value) }
+    2.times do
+      cache.set(key2, @value)
+    end
+
     begin
       cache.get(key2)
     rescue => e

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -1250,6 +1250,8 @@ class MemcachedTest < Minitest::Test
     )
 
     key2 = 'test_missing_server'
+    cache.set(key2, @value)
+
     begin
       cache.get(key2)
     rescue => e

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -6,6 +6,13 @@ class NilClass
   end
 end
 
+# assert_equal calls obj.respond_to?, which isn't supported by NOT_FOUND < BasicObject
+class Memcached
+  def NOT_FOUND.respond_to?(*)
+    false
+  end
+end
+
 class MemcachedTest < Test::Unit::TestCase
   Rlibmemcached = Memcached.const_get(:Lib)
 
@@ -1496,6 +1503,49 @@ class MemcachedTest < Test::Unit::TestCase
 
   def test_interrupt_handling_no_block
     interrupt_test_with_options(key, @noblock_options)
+  end
+
+  # Test returning error values instead of raising
+
+  def test_without_exceptions_get
+    @cache.delete(key) rescue nil
+    @cache.without_exceptions do
+      assert_equal Memcached::NOT_FOUND, @cache.get(key)
+    end
+  end
+
+  def test_cas_without_exceptions
+    value2 = OpenStruct.new(:d => 3, :e => 4, :f => GenericClass)
+
+    @cas_cache.without_exceptions do
+      # Existing set
+      @cas_cache.set key, @value
+      @cas_cache.cas(key) do |current|
+        assert_equal @value, current
+        value2
+      end
+      assert_equal value2, @cas_cache.get(key)
+
+      # Existing test without marshalling
+      @cas_cache.set(key, "foo", 0, false)
+      @cas_cache.cas(key, 0, false) do |current|
+        "#{current}bar"
+      end
+      assert_equal "foobar", @cas_cache.get(key, false)
+
+      # Missing set
+      @cas_cache.delete key
+      assert_equal Memcached::NOT_FOUND, @cas_cache.cas(key) {}
+
+      # Conflicting set
+      @cas_cache.set key, @value
+      assert_raises(Memcached::ConnectionDataExists) do
+        @cas_cache.cas(key) do |current|
+          @cas_cache.set key, value2
+          current
+        end
+      end
+    end
   end
 
   if Process.respond_to?(:fork)

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -1315,7 +1315,7 @@ class MemcachedTest < Minitest::Test
       assert_match(/localhost:43041/, e.message)
     end
   ensure
-    socket.close
+    socket.close if socket
   end
 
   def test_wrong_failure_counter

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -6,14 +6,7 @@ class NilClass
   end
 end
 
-# assert_equal calls obj.respond_to?, which isn't supported by NOT_FOUND < BasicObject
-class Memcached
-  def NOT_FOUND.respond_to?(*)
-    false
-  end
-end
-
-class MemcachedTest < Test::Unit::TestCase
+class MemcachedTest < Minitest::Test
   Rlibmemcached = Memcached.const_get(:Lib)
 
   def setup
@@ -29,6 +22,7 @@ class MemcachedTest < Test::Unit::TestCase
       :distribution => :modula,
       :show_backtraces => true}
     @cache = Memcached.new(@servers, @options)
+    @cache.flush
 
     @binary_protocol_options = {
       :prefix_key => @prefix_key,
@@ -295,7 +289,7 @@ class MemcachedTest < Test::Unit::TestCase
   def test_get_nil
     @cache.set key, nil, 0
     result = @cache.get key
-    assert_equal nil, result
+    assert_nil result
   end
 
   def test_get_from_last

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -1504,7 +1504,7 @@ class MemcachedTest < Minitest::Test
 
   # Test returning error values instead of raising
 
-  def test_without_exceptions_get
+  def test_get_missing_without_exceptions
     @cache.delete(key) rescue nil
     @cache.without_exceptions do
       assert_equal Memcached::NOT_FOUND, @cache.get(key)
@@ -1536,12 +1536,25 @@ class MemcachedTest < Minitest::Test
 
       # Conflicting set
       @cas_cache.set key, @value
-      assert_raises(Memcached::ConnectionDataExists) do
-        @cas_cache.cas(key) do |current|
-          @cas_cache.set key, value2
-          current
-        end
-      end
+      assert_equal Memcached::DATA_EXISTS, (@cas_cache.cas(key) do |current|
+        @cas_cache.set key, value2
+        current
+      end)
+    end
+  end
+
+  def test_existing_add_without_exceptions
+    @cache.without_exceptions do
+      @cache.set key, @value
+      assert_equal Memcached::NOT_STORED, @cache.add(key, @value)
+    end
+  end
+
+  def test_missing_replace_without_exceptions
+    @cache.without_exceptions do
+      @cache.delete key rescue nil
+      assert_equal Memcached::NOT_STORED, @cache.replace(key, @value)
+      assert_equal Memcached::NOT_FOUND, @cache.get(key)
     end
   end
 

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -1282,6 +1282,7 @@ class MemcachedTest < Minitest::Test
   end
 
   def test_unresponsive_server_retries_less_than_server_failure_limit
+    skip "This test is broken"
     socket = stub_server 43041
 
     cache = Memcached.new(


### PR DESCRIPTION
I'd like to experiment with using return values from `get` / `cas` instead of raising exceptions.

I focused on these two methods for now since they seem to be in the critical path of most operations. We could potentially expand this approach out to other methods, and also representing the different regular return states (success, data exists), of `cas` properly.