### PR TITLE
Accept unix:// servers

### DIFF
--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -185,8 +185,8 @@ Please note that when <tt>:no_block => true</tt>, update methods do not raise on
     Array(servers).each_with_index do |server, index|
       # Socket
       check_return_code(
-        if server.is_a?(String) and File.socket?(server)
-          args = [memcached_struct, server, options[:default_weight].to_i]
+        if server.is_a?(String) and (server.start_with?("unix://") || File.socket?(server))
+          args = [memcached_struct, server.sub("unix://", ""), options[:default_weight].to_i]
           Lib.memcached_server_add_unix_socket_with_weight(*args)
         # Network
         elsif server.is_a?(String) and server =~ /^[\w\.-]+(:\d{1,5}){0,2}$/

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -10,7 +10,7 @@ class MemcachedTest < Test::Unit::TestCase
   Rlibmemcached = Memcached.const_get(:Lib)
 
   def setup
-    @servers = ['localhost:43042', 'localhost:43043', "#{UNIX_SOCKET_NAME}0"]
+    @servers = ['localhost:43042', 'localhost:43043', "unix://#{UNIX_SOCKET_NAME}0"]
     @udp_servers = ['localhost:43052', 'localhost:43053']
 
     # Maximum allowed prefix key size for :hash_with_prefix_key_key => false
@@ -235,32 +235,34 @@ class MemcachedTest < Test::Unit::TestCase
       :sort_hosts => false,
       :distribution => :modula
     )
-    assert_equal @servers.sort,
-      cache.servers
+
+    # The unix:// prefix is stripped
+    expected_servers = @servers - ["unix://#{UNIX_SOCKET_NAME}0"]
+    expected_servers.sort!
+    expected_servers << "#{UNIX_SOCKET_NAME}0"
+
+    assert_equal expected_servers, cache.servers
 
     # Original with sort_hosts
     cache = Memcached.new(@servers.sort,
       :sort_hosts => true,
       :distribution => :modula
     )
-    assert_equal @servers.sort,
-      cache.servers
+    assert_equal expected_servers.sort, cache.servers
 
     # Reversed
     cache = Memcached.new(@servers.sort.reverse,
       :sort_hosts => false,
       :distribution => :modula
     )
-      assert_equal @servers.sort.reverse,
-    cache.servers
+    assert_equal expected_servers.reverse, cache.servers
 
     # Reversed with sort_hosts
     cache = Memcached.new(@servers.sort.reverse,
       :sort_hosts => true,
       :distribution => :modula
     )
-    assert_equal @servers.sort,
-      cache.servers
+    assert_equal expected_servers.sort, cache.servers
   end
 
   def test_initialize_single_server


### PR DESCRIPTION
Since the init code check for `File.socket?` for unix paths if the server isn't yet ready the client raise which cause an depedency on the server.

To avoid that we can accept `unix://` URLs, and remove the prefix.

When it there, we can bypass the `File.socket?` check.

