### PR TITLE
Raise Client Error correctly when CAS not supported

### DIFF
--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -450,6 +450,8 @@ Please note that when <tt>:no_block => true</tt>, update methods do not raise on
       value = yield value
       single_cas(keys, value, ttl, flags, cas, decode)
     end
+  rescue ClientError => e
+    raise e
   rescue => e
     raise unless tries < options[:exception_retry_limit] && should_retry(e)
     tries += 1

--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -434,28 +434,28 @@ Please note that when <tt>:no_block => true</tt>, update methods do not raise on
     tries ||= 0
     raise ClientError, "CAS not enabled for this Memcached instance" unless options[:support_cas]
 
-    if keys.is_a? Array
-      # Multi CAS
-      hash, flags_and_cas = multi_get(keys, decode)
-      unless hash.empty?
-        hash = yield hash
-        # Only CAS entries that were updated from the original hash
-        hash.delete_if {|k, _| !flags_and_cas.has_key?(k) }
-        hash = multi_cas(hash, ttl, flags_and_cas, decode, tries)
+    begin
+      if keys.is_a? Array
+        # Multi CAS
+        hash, flags_and_cas = multi_get(keys, decode)
+        unless hash.empty?
+          hash = yield hash
+          # Only CAS entries that were updated from the original hash
+          hash.delete_if {|k, _| !flags_and_cas.has_key?(k) }
+          hash = multi_cas(hash, ttl, flags_and_cas, decode, tries)
+        end
+        hash
+      else
+        # Single CAS
+        value, flags, cas = single_get(keys, decode)
+        value = yield value
+        single_cas(keys, value, ttl, flags, cas, decode)
       end
-      hash
-    else
-      # Single CAS
-      value, flags, cas = single_get(keys, decode)
-      value = yield value
-      single_cas(keys, value, ttl, flags, cas, decode)
+    rescue => e
+      raise unless tries < options[:exception_retry_limit] && should_retry(e)
+      tries += 1
+      retry
     end
-  rescue ClientError => e
-    raise e
-  rescue => e
-    raise unless tries < options[:exception_retry_limit] && should_retry(e)
-    tries += 1
-    retry
   end
 
   alias :compare_and_swap :cas

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -779,6 +779,8 @@ class MemcachedTest < Test::Unit::TestCase
     end
   end
 
+  # CAS
+
   def test_cas
     value2 = OpenStruct.new(:d => 3, :e => 4, :f => GenericClass)
 
@@ -810,6 +812,12 @@ class MemcachedTest < Test::Unit::TestCase
         @cas_cache.set key, value2
         current
       end
+    end
+  end
+
+  def test_cas_raises_client_error_when_not_supported
+    assert_raises(Memcached::ClientError) do
+      @cache.cas(key) {}
     end
   end
 


### PR DESCRIPTION
In a memcached that does not support CAS (the default option) we ended up in the Retry code for CAS. This still ends up raising the error, but there is no point to actually do this. I also added a test case for this command.