### PR TITLE
Fix stack-use-after-scope in _wrap_memcached_fetch_rvalue

### DIFF
--- a/ext/rlibmemcached/rlibmemcached.i
+++ b/ext/rlibmemcached/rlibmemcached.i
@@ -111,12 +111,12 @@
  $result = UINT2NUM($1);
 };
 
-%typemap(in, numinputs=0) (const char **key, size_t *key_length) {
+%typemap(in, numinputs=0) (const char **key, size_t *key_length) "
   const char *key_ptr;
   size_t key_length_ptr;
   $1 = &key_ptr;
   $2 = &key_length_ptr;
-}
+"
 
 // String for memcached_fetch
 %typemap(argout) (const char **key, size_t *key_length) {

--- a/ext/rlibmemcached/rlibmemcached_wrap.c
+++ b/ext/rlibmemcached/rlibmemcached_wrap.c
@@ -12889,13 +12889,11 @@ _wrap_memcached_fetch_rvalue(int argc, VALUE *argv, VALUE self) {
   int res5 = SWIG_TMPOBJ ;
   VALUE result;
   VALUE vresult = Qnil;
-  
-  {
-    const char *key_ptr;
-    size_t key_length_ptr;
-    arg2 = &key_ptr;
-    arg3 = &key_length_ptr;
-  }
+  const char *key_ptr;
+  size_t key_length_ptr;
+
+  arg2 = &key_ptr;
+  arg3 = &key_length_ptr;
   arg4 = &temp4;
   arg5 = &temp5;
   if ((argc < 1) || (argc > 1)) {


### PR DESCRIPTION
`arg2` and `arg3` are pointers to local variables in a block in _wrap_memcached_fetch_rvalue, but they are used after the block ends by being passed into memcached_fetch_rvalue, which writes into these local variables.

This causes the following ASAN error:

    ==496==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7c6820590060 at pc 0x7c67f0f13178 bp 0x7ffefc5fc120 sp 0x7ffefc5fc118
    WRITE of size 8 at 0x7c6820590060 thread T0
        #0 0x7c67f0f13177 in memcached_fetch_rvalue /tmp/bundle/ruby/3.4.0+1/bundler/gems/memcached-54a89bae6988/ext/rlibmemcached/rlibmemcached_wrap.c:2335:10
        #1 0x7c67f0f56c6c in _wrap_memcached_fetch_rvalue /tmp/bundle/ruby/3.4.0+1/bundler/gems/memcached-54a89bae6988/ext/rlibmemcached/rlibmemcached_wrap.c:12909:19
        #2 0x5cb6260d8be8 in vm_call_cfunc_with_frame_ /tmp/ruby-build/ruby-3.4.0-b4d13fac3dd5420475aa1e14fdad8137da7e3ee0/./vm_insnhelper.c:3795:11
        #3 0x5cb6260bba1b in vm_call_method_each_type /tmp/ruby-build/ruby-3.4.0-b4d13fac3dd5420475aa1e14fdad8137da7e3ee0/./vm_insnhelper.c:4773:16
        #4 0x5cb6260bb4da in vm_call_method /tmp/ruby-build/ruby-3.4.0-b4d13fac3dd5420475aa1e14fdad8137da7e3ee0/./vm_insnhelper.c
        #5 0x5cb6260848a8 in vm_sendish /tmp/ruby-build/ruby-3.4.0-b4d13fac3dd5420475aa1e14fdad8137da7e3ee0/./vm_insnhelper.c:5962:15
        #6 0x5cb6260848a8 in vm_exec_core /tmp/ruby-build/ruby-3.4.0-b4d13fac3dd5420475aa1e14fdad8137da7e3ee0/insns.def:898:11