### PR TITLE
Fix buffer overflow by only using snprintf

### DIFF
--- a/vendor/libmemcached-0.32/libmemcached/memcached_storage.c
+++ b/vendor/libmemcached-0.32/libmemcached/memcached_storage.c
@@ -104,32 +104,23 @@ static inline memcached_return memcached_send(memcached_st *ptr,
                                     (ptr->flags & MEM_NOREPLY) ? " noreply" : "");
   else
   {
-    char *buffer_ptr= buffer;
-    const char *command= storage_op_string(verb);
-
-    /* Copy in the command, no space needed, we handle that in the command function*/
-    memcpy(buffer_ptr, command, strlen(command));
-
-    /* Copy in the key prefix, switch to the buffer_ptr */
-    buffer_ptr= memcpy(buffer_ptr + strlen(command) , ptr->prefix_key, strlen(ptr->prefix_key));
-
-    /* Copy in the key, adjust point if a key prefix was used. */
-    buffer_ptr= memcpy(buffer_ptr + (ptr->prefix_key ? strlen(ptr->prefix_key) : 0),
-                       key, key_length);
-    buffer_ptr+= key_length;
-    buffer_ptr[0]=  ' ';
-    buffer_ptr++;
-    write_length= (size_t)(buffer_ptr - buffer);
-
     if (verb == DELETE_OP) {
-      if (ptr->flags & MEM_NOREPLY)
-        write_length+= (size_t) snprintf(buffer_ptr, MEMCACHED_DEFAULT_COMMAND_SIZE, "noreply");
-    } else {
-      write_length+= (size_t) snprintf(buffer_ptr, MEMCACHED_DEFAULT_COMMAND_SIZE,
-                                       "%u %llu %zu%s\r\n",
-                                       flags,
-                                       (unsigned long long)expiration, value_length,
-                                       (ptr->flags & MEM_NOREPLY) ? " noreply" : "");
+      write_length= (size_t) snprintf(buffer, MEMCACHED_DEFAULT_COMMAND_SIZE,
+                                      "%s%s%.*s %s",
+                                      storage_op_string(verb),
+                                      ptr->prefix_key,
+                                      (int)key_length, key,
+                                      (ptr->flags & MEM_NOREPLY) ? "noreply" : "");
+    }
+    else
+    {
+      write_length= (size_t) snprintf(buffer, MEMCACHED_DEFAULT_COMMAND_SIZE,
+                                      "%s%s%.*s %u %llu %zu%s\r\n",
+                                      storage_op_string(verb),
+                                      ptr->prefix_key,
+                                      (int)key_length, key, flags,
+                                      (unsigned long long)expiration, value_length,
+                                      (ptr->flags & MEM_NOREPLY) ? " noreply" : "");
     }
   }
 


### PR DESCRIPTION
Pulling from https://github.com/vinted/memcached/pull/17:

This piece of code contains a buffer overflow issue because it uses a combination of `memcpy` and `snprintf` calls that don't take the remaining buffer capacity into account.

I've used the approach used on line 97 which uses a single `snprintf` call to make sure we don't overrun the buffer.

Without the patch, CI fails with the following crash:

```
cp vendor/libmemcached-0.32/tests/udp.c tmp/x86_64-linux/stage/vendor/libmemcached-0.32/tests/udp.c
install -c tmp/x86_64-linux/rlibmemcached/3.0.7/rlibmemcached.so lib/rlibmemcached.so
cp tmp/x86_64-linux/rlibmemcached/3.0.7/rlibmemcached.so tmp/x86_64-linux/stage/lib/rlibmemcached.so
/home/runner/work/memcached/memcached/lib/memcached.rb:26: warning: already initialized constant Memcached::VERSION
/home/runner/work/memcached/memcached/lib/memcached/version.rb:2: warning: previous definition of VERSION was here
memcached(2403): Operation not permitted
/home/runner/work/memcached/memcached/test/unit/rails_test.rb:9: warning: constant Memcached::Rails is deprecated
/home/runner/work/memcached/memcached/test/unit/rails_test.rb:9: warning: constant Memcached::Rails is deprecated
Loaded suite /home/runner/work/memcached/memcached/vendor/bundle/ruby/3.0.0/gems/rake-13.0.3/lib/rake/rake_test_loader
Started
*** buffer overflow detected ***: terminated
Aborted (core dumped)
rake aborted!
Command failed with status (134)
/home/runner/work/memcached/memcached/vendor/bundle/ruby/3.0.0/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
/opt/hostedtoolcache/Ruby/3.0.7/x64/bin/bundle:23:in `load'
/opt/hostedtoolcache/Ruby/3.0.7/x64/bin/bundle:23:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```