### PR TITLE
Fix integer underflow in memcached_purge

### DIFF
--- a/vendor/libmemcached-0.32/libmemcached/memcached_purge.c
+++ b/vendor/libmemcached-0.32/libmemcached/memcached_purge.c
@@ -30,8 +30,8 @@ memcached_return memcached_purge(memcached_server_st *ptr)
   }
   WATCHPOINT_ASSERT(ptr->fd != -1);
 
-  uint32_t no_msg= memcached_server_response_count(ptr) - 1;
-  if (no_msg > 0)
+  uint32_t no_msg= memcached_server_response_count(ptr);
+  if (no_msg > 1)
   {
     memcached_result_st result;
     memcached_result_st *result_ptr;
@@ -48,7 +48,7 @@ memcached_return memcached_purge(memcached_server_st *ptr)
     result_ptr= memcached_result_create(ptr->root, &result);
     WATCHPOINT_ASSERT(result_ptr);
 
-    for (x= 0; x < no_msg; x++)
+    for (x= 0; x < no_msg - 1; x++)
     {
       memcached_result_reset(result_ptr);
       memcached_return rc= memcached_read_one_response(ptr, buffer,


### PR DESCRIPTION
Pulling https://github.com/vinted/memcached/pull/20, see that PR for context.

<details>
<summary>Reproduction script</summary>

```ruby
#!/usr/bin/env ruby
#
# Reproduce the "bytes == watermark" corner-case in memcached_purge()
# without altering the watermark value.
#
# Works with the vinted-memcached 1.8.x gem that vendors libmemcached-0.32
#
# Mechanics
# 1.  Read the current ptr->root->io_bytes_watermark and the per-server
#     ptr->io_bytes_sent counters from the C structs.
# 2.  Choose a value length L such that the first SET command
#         "set a 0 0 L noreply\r\n".bytes + L + 2  # trailing CRLF
#     will bring io_bytes_sent up to exactly io_bytes_watermark.
# 3.  Send that first SET (with the noreply flag). After it the server's
#     io_bytes_sent == io_bytes_watermark and response_count == 0.
# 4.  Send a second tiny SET (also noreply). This triggers the
#     equality-case branch inside memcached_purge(), reproducing the busy-loop
#     bug in unpatched libmemcached.

require 'memcached'

puts "Process.pid: #{Process.pid} (use `kill -9 #{Process.pid}` to stop)"

KEY1 = 'a'
KEY2 = 'b'

client = Memcached.new('127.0.0.1:11211', noreply: true, no_block: true)

lib = Memcached.const_get(:Lib)
struct = client.instance_variable_get(:@struct)
server = client.send(:server_structs).first

watermark = struct.io_bytes_watermark
bytes_sent = server.io_bytes_sent # you could assume 0 for new connections instead
expected_bytes_count = 27 # expected length of the first SET command
value_len = watermark - bytes_sent - expected_bytes_count

puts "Current bytes sent: #{bytes_sent}"
puts "Current io_bytes_watermark: #{watermark}"
puts "Chosen value length: #{value_len} (total bytes will match watermark)"

# 1st write - drives io_bytes_sent == watermark
client.set(KEY1, 'x' * value_len, 0, false, 0)

# 2nd write - triggers the equality-case path
client.set(KEY2, 'y')

# With a vulnerable libmemcached build the script will now spin at 100% CPU
puts 'If this line prints, the loop did not trigger - your libmemcached is patched.'
```

</details>