### PR TITLE
Fix buffer overflow in memcached_send

### DIFF
--- a/vendor/libmemcached-0.32/libmemcached/memcached_storage.c
+++ b/vendor/libmemcached-0.32/libmemcached/memcached_storage.c
@@ -123,9 +123,9 @@ static inline memcached_return memcached_send(memcached_st *ptr,
 
     if (verb == DELETE_OP) {
       if (ptr->flags & MEM_NOREPLY)
-        write_length+= (size_t) snprintf(buffer_ptr, MEMCACHED_DEFAULT_COMMAND_SIZE, "noreply");
+        write_length+= (size_t) snprintf(buffer_ptr, MEMCACHED_DEFAULT_COMMAND_SIZE - write_length, "noreply");
     } else {
-      write_length+= (size_t) snprintf(buffer_ptr, MEMCACHED_DEFAULT_COMMAND_SIZE,
+      write_length+= (size_t) snprintf(buffer_ptr, MEMCACHED_DEFAULT_COMMAND_SIZE - write_length,
                                        "%u %llu %zu%s\r\n",
                                        flags,
                                        (unsigned long long)expiration, value_length,


### PR DESCRIPTION
We need to account for the existing memory in `buffer` so we don't overflow and write past in end in `snprintf`.